### PR TITLE
Add reference lookup endpoints and integrate localized frontend data

### DIFF
--- a/app/src/index.css
+++ b/app/src/index.css
@@ -6,26 +6,54 @@
   color-scheme: light;
 }
 
+:root.dark {
+  color-scheme: dark;
+}
+
 body {
   @apply bg-slate-100 text-slate-800;
+}
+
+:root.dark body {
+  @apply bg-slate-900 text-slate-100;
 }
 
 .btn-primary {
   @apply inline-flex items-center justify-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white shadow-soft transition hover:bg-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-400 focus:ring-offset-2;
 }
 
+.dark .btn-primary {
+  @apply bg-primary-500 text-white hover:bg-primary-400 focus:ring-primary-300 focus:ring-offset-slate-800;
+}
+
 .btn-secondary {
   @apply inline-flex items-center justify-center gap-2 rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-primary-300 hover:text-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-400 focus:ring-offset-2;
+}
+
+.dark .btn-secondary {
+  @apply border-slate-700 bg-slate-800 text-slate-200 hover:border-primary-500 hover:text-primary-300 focus:ring-primary-500 focus:ring-offset-slate-900;
 }
 
 .badge {
   @apply inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold;
 }
 
+.dark .badge {
+  @apply bg-slate-800 text-slate-200;
+}
+
 .card {
   @apply rounded-2xl border border-slate-200 bg-white p-6 shadow-sm;
 }
 
+.dark .card {
+  @apply border-slate-700 bg-slate-800 text-slate-100 shadow-none;
+}
+
 .input {
   @apply w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm placeholder-slate-400 focus:border-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-400;
+}
+
+.dark .input {
+  @apply border-slate-700 bg-slate-900 text-slate-100 placeholder-slate-500 focus:border-primary-500 focus:ring-primary-500;
 }

--- a/app/src/locales/en.js
+++ b/app/src/locales/en.js
@@ -70,6 +70,14 @@ export default {
           label: 'Country',
           placeholder: 'Country',
         },
+        education: {
+          label: 'Education level',
+          placeholder: 'Select an education level',
+        },
+        profession: {
+          label: 'Profession',
+          placeholder: 'Select a profession',
+        },
       },
       actions: {
         save: 'Save changes',

--- a/app/src/locales/pt.js
+++ b/app/src/locales/pt.js
@@ -70,6 +70,14 @@ export default {
           label: 'País',
           placeholder: 'Brasil',
         },
+        education: {
+          label: 'Escolaridade',
+          placeholder: 'Selecione a escolaridade',
+        },
+        profession: {
+          label: 'Profissão',
+          placeholder: 'Selecione a profissão',
+        },
       },
       actions: {
         save: 'Salvar alterações',

--- a/app/src/services/reference.js
+++ b/app/src/services/reference.js
@@ -1,0 +1,28 @@
+import api from './api';
+
+export const getCountries = (params = {}) => api.get('/api/v1/reference/countries', { params });
+
+export const getCities = (countryId, params = {}) =>
+  api.get(`/api/v1/reference/countries/${countryId}/cities`, { params });
+
+export const getEducationLevels = (params = {}) =>
+  api.get('/api/v1/reference/education-levels', { params });
+
+export const getProfessions = (params = {}) =>
+  api.get('/api/v1/reference/professions', { params });
+
+export const getMeasurementUnits = (params = {}) =>
+  api.get('/api/v1/reference/measurement-units', { params });
+
+export const getFoodCategories = (params = {}) =>
+  api.get('/api/v1/reference/food-categories', { params });
+
+export const getFoods = (params = {}) => api.get('/api/v1/reference/foods', { params });
+
+export const getMeals = (params = {}) => api.get('/api/v1/reference/meals', { params });
+
+export const getPathologies = (params = {}) =>
+  api.get('/api/v1/reference/pathologies', { params });
+
+export const getBiochemicalExams = (params = {}) =>
+  api.get('/api/v1/reference/biochemical-exams', { params });

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <org.mapstruct.version>1.6.3</org.mapstruct.version>
         <aws.sdk.version>2.20.0</aws.sdk.version>
         <spring.boot.version>3.0.0</spring.boot.version>
+        <lombok.version>1.18.32</lombok.version>
     </properties>
     <dependencies>
         <dependency>
@@ -258,6 +259,11 @@
                         <groupId>org.mapstruct</groupId>
                         <artifactId>mapstruct-processor</artifactId>
                         <version>${org.mapstruct.version}</version>
+                    </path>
+                    <path>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <version>${lombok.version}</version>
                     </path>
                     <!-- other annotation processors -->
                 </annotationProcessorPaths>

--- a/src/main/java/com/jm/controllers/ReferenceDataController.java
+++ b/src/main/java/com/jm/controllers/ReferenceDataController.java
@@ -1,0 +1,107 @@
+package com.jm.controllers;
+
+import com.jm.dto.BiochemicalExamDTO;
+import com.jm.dto.CityDTO;
+import com.jm.dto.CountryDTO;
+import com.jm.dto.EducationLevelDTO;
+import com.jm.dto.FoodCategoryDTO;
+import com.jm.dto.FoodDTO;
+import com.jm.dto.MealDTO;
+import com.jm.dto.MeasurementUnitDTO;
+import com.jm.dto.PathologyDTO;
+import com.jm.dto.ProfessionDTO;
+import com.jm.services.BiochemicalExamService;
+import com.jm.services.CityService;
+import com.jm.services.CountryService;
+import com.jm.services.EducationLevelService;
+import com.jm.services.FoodCategoryService;
+import com.jm.services.FoodService;
+import com.jm.services.MealService;
+import com.jm.services.MeasurementUnitService;
+import com.jm.services.PathologyService;
+import com.jm.services.ProfessionService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/reference")
+@Tag(name = "Reference data", description = "Lookup tables for nutrition and profile data")
+@RequiredArgsConstructor
+public class ReferenceDataController {
+
+    private final CountryService countryService;
+    private final CityService cityService;
+    private final EducationLevelService educationLevelService;
+    private final ProfessionService professionService;
+    private final MeasurementUnitService measurementUnitService;
+    private final FoodCategoryService foodCategoryService;
+    private final FoodService foodService;
+    private final MealService mealService;
+    private final PathologyService pathologyService;
+    private final BiochemicalExamService biochemicalExamService;
+
+    @GetMapping("/countries")
+    public ResponseEntity<List<CountryDTO>> listCountries(@RequestParam(required = false) String language) {
+        return ResponseEntity.ok(countryService.findAll(language));
+    }
+
+    @GetMapping("/countries/{countryId}/cities")
+    public ResponseEntity<List<CityDTO>> listCities(@PathVariable UUID countryId,
+            @RequestParam(required = false) String language) {
+        return ResponseEntity.ok(cityService.findByCountry(countryId, language));
+    }
+
+    @GetMapping("/education-levels")
+    public ResponseEntity<List<EducationLevelDTO>> listEducationLevels(
+            @RequestParam(required = false) String language) {
+        return ResponseEntity.ok(educationLevelService.findAll(language));
+    }
+
+    @GetMapping("/professions")
+    public ResponseEntity<List<ProfessionDTO>> listProfessions(@RequestParam(required = false) String language) {
+        return ResponseEntity.ok(professionService.findAll(language));
+    }
+
+    @GetMapping("/measurement-units")
+    public ResponseEntity<List<MeasurementUnitDTO>> listMeasurementUnits(
+            @RequestParam(required = false) String language) {
+        return ResponseEntity.ok(measurementUnitService.findAll(language));
+    }
+
+    @GetMapping("/food-categories")
+    public ResponseEntity<List<FoodCategoryDTO>> listFoodCategories(
+            @RequestParam(required = false) String language) {
+        return ResponseEntity.ok(foodCategoryService.findAll(language));
+    }
+
+    @GetMapping("/foods")
+    public ResponseEntity<List<FoodDTO>> listFoods(@RequestParam(required = false) String language,
+            @RequestParam(required = false) UUID categoryId) {
+        return ResponseEntity.ok(foodService.findAll(language, categoryId));
+    }
+
+    @GetMapping("/meals")
+    public ResponseEntity<List<MealDTO>> listMeals(@RequestParam(required = false) String language) {
+        return ResponseEntity.ok(mealService.findAll(language));
+    }
+
+    @GetMapping("/pathologies")
+    public ResponseEntity<List<PathologyDTO>> listPathologies(@RequestParam(required = false) String language) {
+        return ResponseEntity.ok(pathologyService.findAll(language));
+    }
+
+    @GetMapping("/biochemical-exams")
+    public ResponseEntity<List<BiochemicalExamDTO>> listBiochemicalExams(
+            @RequestParam(required = false) String language) {
+        return ResponseEntity.ok(biochemicalExamService.findAll(language));
+    }
+}

--- a/src/main/java/com/jm/dto/BiochemicalExamDTO.java
+++ b/src/main/java/com/jm/dto/BiochemicalExamDTO.java
@@ -1,0 +1,25 @@
+package com.jm.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BiochemicalExamDTO {
+
+    private UUID id;
+    private String code;
+    private String name;
+    private String description;
+    private UUID measurementUnitId;
+    private String measurementUnitName;
+    private BigDecimal minReferenceValue;
+    private BigDecimal maxReferenceValue;
+}

--- a/src/main/java/com/jm/dto/CityDTO.java
+++ b/src/main/java/com/jm/dto/CityDTO.java
@@ -1,0 +1,28 @@
+package com.jm.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CityDTO {
+
+    private UUID id;
+    private UUID countryId;
+    private String stateCode;
+    private String stateName;
+    private String cityCode;
+    private String name;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+    private Integer population;
+    private String timezone;
+    private Boolean capital;
+}

--- a/src/main/java/com/jm/dto/EducationLevelDTO.java
+++ b/src/main/java/com/jm/dto/EducationLevelDTO.java
@@ -1,23 +1,21 @@
 package com.jm.dto;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CountryDTO {
+public class EducationLevelDTO {
 
     private UUID id;
     private String code;
     private String name;
-    private String nationality;
-    private String language;
-    private LocalDateTime createdAt;
+    private String description;
+    private Integer sortOrder;
 }

--- a/src/main/java/com/jm/dto/FoodCategoryDTO.java
+++ b/src/main/java/com/jm/dto/FoodCategoryDTO.java
@@ -1,23 +1,20 @@
 package com.jm.dto;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CountryDTO {
+public class FoodCategoryDTO {
 
     private UUID id;
-    private String code;
     private String name;
-    private String nationality;
-    private String language;
-    private LocalDateTime createdAt;
+    private String description;
+    private String color;
 }

--- a/src/main/java/com/jm/dto/FoodDTO.java
+++ b/src/main/java/com/jm/dto/FoodDTO.java
@@ -1,0 +1,30 @@
+package com.jm.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FoodDTO {
+
+    private UUID id;
+    private String code;
+    private String name;
+    private String description;
+    private UUID categoryId;
+    private String categoryName;
+    private BigDecimal averageCalories;
+    private BigDecimal averageProtein;
+    private BigDecimal averageCarbs;
+    private BigDecimal averageFat;
+    private BigDecimal commonPortion;
+    private UUID commonPortionUnitId;
+    private String commonPortionUnitName;
+}

--- a/src/main/java/com/jm/dto/MealDTO.java
+++ b/src/main/java/com/jm/dto/MealDTO.java
@@ -1,23 +1,23 @@
 package com.jm.dto;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalTime;
+import java.util.UUID;
+
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CountryDTO {
+public class MealDTO {
 
     private UUID id;
     private String code;
     private String name;
-    private String nationality;
-    private String language;
-    private LocalDateTime createdAt;
+    private String description;
+    private LocalTime typicalTime;
+    private Integer sortOrder;
 }

--- a/src/main/java/com/jm/dto/MeasurementUnitDTO.java
+++ b/src/main/java/com/jm/dto/MeasurementUnitDTO.java
@@ -1,0 +1,25 @@
+package com.jm.dto;
+
+import com.jm.entity.MeasurementUnits;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MeasurementUnitDTO {
+
+    private UUID id;
+    private String code;
+    private String name;
+    private String symbol;
+    private MeasurementUnits.UnitType unitType;
+    private Double conversionFactor;
+    private Boolean baseUnit;
+    private String description;
+}

--- a/src/main/java/com/jm/dto/PathologyDTO.java
+++ b/src/main/java/com/jm/dto/PathologyDTO.java
@@ -1,23 +1,23 @@
 package com.jm.dto;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CountryDTO {
+public class PathologyDTO {
 
     private UUID id;
     private String code;
     private String name;
-    private String nationality;
-    private String language;
-    private LocalDateTime createdAt;
+    private String description;
+    private String category;
+    private Boolean chronic;
+    private Boolean requiresMonitoring;
 }

--- a/src/main/java/com/jm/dto/ProfessionDTO.java
+++ b/src/main/java/com/jm/dto/ProfessionDTO.java
@@ -1,23 +1,20 @@
 package com.jm.dto;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CountryDTO {
+public class ProfessionDTO {
 
     private UUID id;
     private String code;
     private String name;
-    private String nationality;
-    private String language;
-    private LocalDateTime createdAt;
+    private String description;
 }

--- a/src/main/java/com/jm/dto/UserDTO.java
+++ b/src/main/java/com/jm/dto/UserDTO.java
@@ -24,11 +24,16 @@ public class UserDTO {
     private String documentNumber;
     private String phoneNumber;
     private String street;
-    private String city;
     private String state;
     private String postalCode;
+    private UUID cityId;
+    private String cityName;
     private UUID countryId;
     private CountryDTO countryDTO;
+    private UUID educationLevelId;
+    private String educationLevelName;
+    private UUID professionId;
+    private String professionName;
     private String password;
     private String avatarUrl;
     private Users.Type type;
@@ -36,7 +41,5 @@ public class UserDTO {
     private String asaasCustomerId;
     private LocalDate birthDate;
     private Integer age;
-    private String education;
-    private String occupation;
     private String consultationGoal;
 }

--- a/src/main/java/com/jm/entity/BiochemicalExam.java
+++ b/src/main/java/com/jm/entity/BiochemicalExam.java
@@ -12,8 +12,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -45,8 +46,8 @@ public class BiochemicalExam {
     @Column(nullable = true, length = 50)
     private String description;
 
-    @OneToOne
-    @JoinColumn(name = "measurement_unit_id", referencedColumnName = "id", nullable = false, unique = true)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "measurement_unit_id", nullable = false)
     private MeasurementUnits measurementUnit;
 
     @Column(name = "min_reference_value", precision = 10, scale = 2)

--- a/src/main/java/com/jm/entity/City.java
+++ b/src/main/java/com/jm/entity/City.java
@@ -79,4 +79,7 @@ public class City {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @Column(name = "language", length = 5)
+    private String language;
+
 }

--- a/src/main/java/com/jm/entity/EducationLevel.java
+++ b/src/main/java/com/jm/entity/EducationLevel.java
@@ -36,6 +36,12 @@ public class EducationLevel {
     @Column(unique = true, nullable = false, length = 50)
     private String code;
 
+    @Column(nullable = false, length = 120)
+    private String name;
+
+    @Column(length = 255)
+    private String description;
+
     @Column(name = "sort_order")
     private Integer sortOrder = 0;
 

--- a/src/main/java/com/jm/entity/Food.java
+++ b/src/main/java/com/jm/entity/Food.java
@@ -2,7 +2,6 @@ package com.jm.entity;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
 import org.hibernate.annotations.CreationTimestamp;
@@ -46,6 +45,12 @@ public class Food {
     @JoinColumn(name = "food_category_id", nullable = false)
     private FoodCategory foodCategory;
 
+    @Column(nullable = false, length = 150)
+    private String name;
+
+    @Column(length = 255)
+    private String description;
+
     @Column(name = "average_calories", precision = 8, scale = 2)
     private BigDecimal averageCalories;
 
@@ -61,8 +66,9 @@ public class Food {
     @Column(name = "common_portion", precision = 8, scale = 2)
     private BigDecimal commonPortion;
 
-    @Column(name = "common_portion_unit", length = 20)
-    private String commonPortionUnit;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "common_portion_unit_id")
+    private MeasurementUnits commonPortionUnit;
 
     @Column(name = "is_active")
     private Boolean isActive = true;

--- a/src/main/java/com/jm/entity/FoodCategory.java
+++ b/src/main/java/com/jm/entity/FoodCategory.java
@@ -47,6 +47,9 @@ public class FoodCategory {
     @OneToMany(mappedBy = "foodCategory", fetch = FetchType.LAZY)
     private List<Food> foods = new ArrayList<>();
 
+    @Column(name = "language", length = 5)
+    private String language;
+
     @Column(name = "created_at")
     private OffsetDateTime createdAt;
 

--- a/src/main/java/com/jm/entity/Meal.java
+++ b/src/main/java/com/jm/entity/Meal.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name = "foods")
+@Table(name = "meals")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -37,6 +37,12 @@ public class Meal {
     @Column(unique = true, nullable = false, length = 50)
     private String code;
 
+    @Column(nullable = false, length = 120)
+    private String name;
+
+    @Column(length = 255)
+    private String description;
+
     @Column(name = "typical_time")
     private LocalTime typicalTime;
 
@@ -49,5 +55,4 @@ public class Meal {
 
     @Column(name = "language", length = 5)
     private String language;
-
 }

--- a/src/main/java/com/jm/entity/Pathology.java
+++ b/src/main/java/com/jm/entity/Pathology.java
@@ -36,6 +36,12 @@ public class Pathology {
     @Column(unique = true, nullable = false, length = 50)
     private String code;
 
+    @Column(nullable = false, length = 150)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
     @Column(length = 50)
     private String category;
 

--- a/src/main/java/com/jm/entity/Profession.java
+++ b/src/main/java/com/jm/entity/Profession.java
@@ -36,6 +36,12 @@ public class Profession {
     @Column(unique = true, nullable = false, length = 50)
     private String code;
 
+    @Column(nullable = false, length = 150)
+    private String name;
+
+    @Column(length = 255)
+    private String description;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/jm/entity/Users.java
+++ b/src/main/java/com/jm/entity/Users.java
@@ -1,6 +1,17 @@
 package com.jm.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -8,11 +19,10 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
-import java.time.LocalDate;
 
 @Entity
 @Data
@@ -22,51 +32,66 @@ import java.time.LocalDate;
 @Table(name = "user_entity")
 public class Users {
 
-        @Id
-        @GeneratedValue(generator = "UUID")
-        @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator", parameters = {
-                        @Parameter(name = "uuid_gen_strategy_class", value = "org.hibernate.id.uuid.CustomVersionOneStrategy") })
-        @Column(name = "id", updatable = false, nullable = false)
-        private UUID id;
+    @Id
+    @GeneratedValue(generator = "UUID")
+    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator", parameters = {
+            @Parameter(name = "uuid_gen_strategy_class", value = "org.hibernate.id.uuid.CustomVersionOneStrategy")
+    })
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
 
-        private String name;
-        private String lastName;
-        private String email;
-        private int hashCode;
+    private String name;
+    private String lastName;
+    private String email;
+    private int hashCode;
 
-        private String password;
-        @Enumerated(EnumType.STRING)
-        private Type type;
+    private String password;
 
-        private String documentNumber;
-        private String phoneNumber;
+    @Enumerated(EnumType.STRING)
+    private Type type;
 
-        private String street;
-        private String city;
-        private String state;
-        private String postalCode;
-        @OneToOne(fetch = FetchType.LAZY)
-        @JoinColumn(name = "country_id", referencedColumnName = "id", nullable = false, unique = true)
-        private Country country;
-        private String avatarUrl;
+    private String documentNumber;
+    private String phoneNumber;
 
-        private String stripeCustomerId;
-        private String asaasCustomerId;
+    private String street;
 
-        private LocalDate birthDate;
-        private Integer age;
-        private String education;
-        private String occupation;
-        @Column(length = 1000)
-        private String consultationGoal;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "city_id")
+    private City city;
 
-        @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
-        private List<Image> imagens = new ArrayList<>();
+    private String state;
+    private String postalCode;
 
-        @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-        private List<Anamnese> anamneses = new ArrayList<>();
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "country_id")
+    private Country country;
 
-        public enum Type {
-                ADMIN, CLIENT;
-        }
+    private String avatarUrl;
+
+    private String stripeCustomerId;
+    private String asaasCustomerId;
+
+    private LocalDate birthDate;
+    private Integer age;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "education_level_id")
+    private EducationLevel educationLevel;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profession_id")
+    private Profession profession;
+
+    @Column(length = 1000)
+    private String consultationGoal;
+
+    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
+    private List<Image> imagens = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Anamnese> anamneses = new ArrayList<>();
+
+    public enum Type {
+        ADMIN, CLIENT
+    }
 }

--- a/src/main/java/com/jm/mappers/UserMapper.java
+++ b/src/main/java/com/jm/mappers/UserMapper.java
@@ -14,27 +14,37 @@ public class UserMapper {
         if (entity == null) {
             return null;
         }
+
+        var country = entity.getCountry();
+        var city = entity.getCity();
+        var education = entity.getEducationLevel();
+        var profession = entity.getProfession();
+
         return UserDTO.builder()
                 .id(entity.getId())
                 .name(entity.getName())
                 .email(entity.getEmail())
                 .lastName(entity.getLastName())
-                .city(entity.getCity())
                 .documentNumber(entity.getDocumentNumber())
                 .phoneNumber(entity.getPhoneNumber())
                 .postalCode(entity.getPostalCode())
                 .state(entity.getState())
                 .street(entity.getStreet())
+                .cityId(city != null ? city.getId() : null)
+                .cityName(city != null ? city.getName() : null)
+                .countryId(country != null ? country.getId() : null)
+                .countryDTO(country != null ? countryMapper.toDTO(country) : null)
+                .educationLevelId(education != null ? education.getId() : null)
+                .educationLevelName(education != null ? education.getName() : null)
+                .professionId(profession != null ? profession.getId() : null)
+                .professionName(profession != null ? profession.getName() : null)
                 .type(entity.getType())
                 .avatarUrl(entity.getAvatarUrl())
                 .stripeCustomerId(entity.getStripeCustomerId())
                 .asaasCustomerId(entity.getAsaasCustomerId())
                 .birthDate(entity.getBirthDate())
                 .age(entity.getAge())
-                .education(entity.getEducation())
-                .occupation(entity.getOccupation())
                 .consultationGoal(entity.getConsultationGoal())
-                .countryDTO(countryMapper.toDTO(entity.getCountry()))
                 .build();
     }
 
@@ -47,7 +57,6 @@ public class UserMapper {
                 .name(userDTO.getName())
                 .email(userDTO.getEmail())
                 .lastName(userDTO.getLastName())
-                .city(userDTO.getCity())
                 .documentNumber(userDTO.getDocumentNumber())
                 .phoneNumber(userDTO.getPhoneNumber())
                 .postalCode(userDTO.getPostalCode())
@@ -60,8 +69,6 @@ public class UserMapper {
                 .asaasCustomerId(userDTO.getAsaasCustomerId())
                 .birthDate(userDTO.getBirthDate())
                 .age(userDTO.getAge())
-                .education(userDTO.getEducation())
-                .occupation(userDTO.getOccupation())
                 .consultationGoal(userDTO.getConsultationGoal())
                 .build();
     }
@@ -70,7 +77,6 @@ public class UserMapper {
         entity.setName(entity.getName());
         entity.setHashCode(entity.getHashCode());
         entity.setLastName(entity.getLastName());
-        entity.setCity(entity.getCity());
         entity.setCountry(entity.getCountry());
         entity.setDocumentNumber(entity.getDocumentNumber());
         entity.setPhoneNumber(entity.getPhoneNumber());

--- a/src/main/java/com/jm/repository/BiochemicalExamRepository.java
+++ b/src/main/java/com/jm/repository/BiochemicalExamRepository.java
@@ -1,0 +1,16 @@
+package com.jm.repository;
+
+import com.jm.entity.BiochemicalExam;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface BiochemicalExamRepository extends JpaRepository<BiochemicalExam, UUID> {
+
+    List<BiochemicalExam> findByLanguageIgnoreCaseOrLanguageIsNullOrderByNameAsc(String language);
+
+    List<BiochemicalExam> findAllByOrderByNameAsc();
+}

--- a/src/main/java/com/jm/repository/CityRepository.java
+++ b/src/main/java/com/jm/repository/CityRepository.java
@@ -1,0 +1,18 @@
+package com.jm.repository;
+
+import com.jm.entity.City;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface CityRepository extends JpaRepository<City, UUID> {
+
+    List<City> findByCountryIdOrderByNameAsc(UUID countryId);
+
+    List<City> findByCountryIdAndLanguageIgnoreCaseOrderByNameAsc(UUID countryId, String language);
+
+    List<City> findByCountryIdAndLanguageIsNullOrderByNameAsc(UUID countryId);
+}

--- a/src/main/java/com/jm/repository/CountryRepository.java
+++ b/src/main/java/com/jm/repository/CountryRepository.java
@@ -5,8 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface CountryRepository extends JpaRepository<Country, UUID>, JpaSpecificationExecutor<Country> {
+
+    List<Country> findByLanguageIgnoreCaseOrLanguageIsNullOrderByNameAsc(String language);
+
+    List<Country> findAllByOrderByNameAsc();
 }

--- a/src/main/java/com/jm/repository/EducationLevelRepository.java
+++ b/src/main/java/com/jm/repository/EducationLevelRepository.java
@@ -1,0 +1,16 @@
+package com.jm.repository;
+
+import com.jm.entity.EducationLevel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface EducationLevelRepository extends JpaRepository<EducationLevel, UUID> {
+
+    List<EducationLevel> findByLanguageIgnoreCaseOrLanguageIsNullOrderBySortOrderAscNameAsc(String language);
+
+    List<EducationLevel> findAllByOrderBySortOrderAscNameAsc();
+}

--- a/src/main/java/com/jm/repository/FoodCategoryRepository.java
+++ b/src/main/java/com/jm/repository/FoodCategoryRepository.java
@@ -2,10 +2,18 @@ package com.jm.repository;
 
 import com.jm.entity.FoodCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+@Repository
 public interface FoodCategoryRepository extends JpaRepository<FoodCategory, UUID> {
+
     Optional<FoodCategory> findByNameIgnoreCase(String name);
+
+    List<FoodCategory> findByLanguageIgnoreCaseOrLanguageIsNullOrderByNameAsc(String language);
+
+    List<FoodCategory> findAllByOrderByNameAsc();
 }

--- a/src/main/java/com/jm/repository/FoodRepository.java
+++ b/src/main/java/com/jm/repository/FoodRepository.java
@@ -1,0 +1,22 @@
+package com.jm.repository;
+
+import com.jm.entity.Food;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface FoodRepository extends JpaRepository<Food, UUID> {
+
+    List<Food> findByLanguageIgnoreCaseOrderByNameAsc(String language);
+
+    List<Food> findByLanguageIsNullOrderByNameAsc();
+
+    List<Food> findByFoodCategoryIdAndLanguageIgnoreCaseOrderByNameAsc(UUID categoryId, String language);
+
+    List<Food> findByFoodCategoryIdAndLanguageIsNullOrderByNameAsc(UUID categoryId);
+
+    List<Food> findAllByOrderByNameAsc();
+}

--- a/src/main/java/com/jm/repository/MealRepository.java
+++ b/src/main/java/com/jm/repository/MealRepository.java
@@ -1,0 +1,16 @@
+package com.jm.repository;
+
+import com.jm.entity.Meal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface MealRepository extends JpaRepository<Meal, UUID> {
+
+    List<Meal> findByLanguageIgnoreCaseOrLanguageIsNullOrderBySortOrderAscNameAsc(String language);
+
+    List<Meal> findAllByOrderBySortOrderAscNameAsc();
+}

--- a/src/main/java/com/jm/repository/MeasurementUnitRepository.java
+++ b/src/main/java/com/jm/repository/MeasurementUnitRepository.java
@@ -1,0 +1,16 @@
+package com.jm.repository;
+
+import com.jm.entity.MeasurementUnits;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface MeasurementUnitRepository extends JpaRepository<MeasurementUnits, UUID> {
+
+    List<MeasurementUnits> findByLanguageIgnoreCaseOrLanguageIsNullOrderByNameAsc(String language);
+
+    List<MeasurementUnits> findAllByOrderByNameAsc();
+}

--- a/src/main/java/com/jm/repository/PathologyRepository.java
+++ b/src/main/java/com/jm/repository/PathologyRepository.java
@@ -1,0 +1,16 @@
+package com.jm.repository;
+
+import com.jm.entity.Pathology;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface PathologyRepository extends JpaRepository<Pathology, UUID> {
+
+    List<Pathology> findByLanguageIgnoreCaseOrLanguageIsNullOrderByNameAsc(String language);
+
+    List<Pathology> findAllByOrderByNameAsc();
+}

--- a/src/main/java/com/jm/repository/ProfessionRepository.java
+++ b/src/main/java/com/jm/repository/ProfessionRepository.java
@@ -1,0 +1,16 @@
+package com.jm.repository;
+
+import com.jm.entity.Profession;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface ProfessionRepository extends JpaRepository<Profession, UUID> {
+
+    List<Profession> findByLanguageIgnoreCaseOrLanguageIsNullOrderByNameAsc(String language);
+
+    List<Profession> findAllByOrderByNameAsc();
+}

--- a/src/main/java/com/jm/services/AnamneseService.java
+++ b/src/main/java/com/jm/services/AnamneseService.java
@@ -150,8 +150,6 @@ public class AnamneseService {
         }
         user.setBirthDate(dto.getDataNascimento());
         user.setAge(dto.getIdade());
-        user.setEducation(dto.getEscolaridade());
-        user.setOccupation(dto.getProfissao());
         user.setConsultationGoal(dto.getObjetivoConsulta());
     }
 

--- a/src/main/java/com/jm/services/BiochemicalExamService.java
+++ b/src/main/java/com/jm/services/BiochemicalExamService.java
@@ -1,0 +1,48 @@
+package com.jm.services;
+
+import com.jm.dto.BiochemicalExamDTO;
+import com.jm.entity.BiochemicalExam;
+import com.jm.repository.BiochemicalExamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BiochemicalExamService {
+
+    private final BiochemicalExamRepository repository;
+
+    public List<BiochemicalExamDTO> findAll(String language) {
+        Map<UUID, BiochemicalExam> accumulator = new LinkedHashMap<>();
+        if (StringUtils.hasText(language)) {
+            repository.findByLanguageIgnoreCaseOrLanguageIsNullOrderByNameAsc(language)
+                    .forEach(exam -> accumulator.put(exam.getId(), exam));
+        } else {
+            repository.findAllByOrderByNameAsc()
+                    .forEach(exam -> accumulator.put(exam.getId(), exam));
+        }
+        return accumulator.values().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private BiochemicalExamDTO toDto(BiochemicalExam entity) {
+        return BiochemicalExamDTO.builder()
+                .id(entity.getId())
+                .code(entity.getCode())
+                .name(entity.getName())
+                .description(entity.getDescription())
+                .measurementUnitId(entity.getMeasurementUnit() != null ? entity.getMeasurementUnit().getId() : null)
+                .measurementUnitName(entity.getMeasurementUnit() != null ? entity.getMeasurementUnit().getName() : null)
+                .minReferenceValue(entity.getMinReferenceValue())
+                .maxReferenceValue(entity.getMaxReferenceValue())
+                .build();
+    }
+}

--- a/src/main/java/com/jm/services/CityService.java
+++ b/src/main/java/com/jm/services/CityService.java
@@ -1,0 +1,62 @@
+package com.jm.services;
+
+import com.jm.dto.CityDTO;
+import com.jm.entity.City;
+import com.jm.repository.CityRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CityService {
+
+    private final CityRepository cityRepository;
+
+    public List<CityDTO> findByCountry(UUID countryId, String language) {
+        if (countryId == null) {
+            return List.of();
+        }
+
+        Map<UUID, City> accumulator = new LinkedHashMap<>();
+        if (StringUtils.hasText(language)) {
+            cityRepository.findByCountryIdAndLanguageIgnoreCaseOrderByNameAsc(countryId, language)
+                    .forEach(city -> accumulator.put(city.getId(), city));
+        } else {
+            cityRepository.findByCountryIdOrderByNameAsc(countryId)
+                    .forEach(city -> accumulator.put(city.getId(), city));
+        }
+
+        cityRepository.findByCountryIdAndLanguageIsNullOrderByNameAsc(countryId)
+                .forEach(city -> accumulator.putIfAbsent(city.getId(), city));
+
+        return accumulator.values().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private CityDTO toDto(City city) {
+        if (city == null) {
+            return null;
+        }
+        return CityDTO.builder()
+                .id(city.getId())
+                .countryId(city.getCountry() != null ? city.getCountry().getId() : null)
+                .stateCode(city.getStateCode())
+                .stateName(city.getStateName())
+                .cityCode(city.getCityCode())
+                .name(city.getName())
+                .latitude(city.getLatitude())
+                .longitude(city.getLongitude())
+                .population(city.getPopulation())
+                .timezone(city.getTimezone())
+                .capital(Boolean.TRUE.equals(city.getIsCapital()))
+                .build();
+    }
+}

--- a/src/main/java/com/jm/services/CountryService.java
+++ b/src/main/java/com/jm/services/CountryService.java
@@ -1,0 +1,31 @@
+package com.jm.services;
+
+import com.jm.dto.CountryDTO;
+import com.jm.mappers.CountryMapper;
+import com.jm.repository.CountryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CountryService {
+
+    private final CountryRepository countryRepository;
+    private final CountryMapper countryMapper;
+
+    public List<CountryDTO> findAll(String language) {
+        List<com.jm.entity.Country> countries;
+        if (StringUtils.hasText(language)) {
+            countries = countryRepository.findByLanguageIgnoreCaseOrLanguageIsNullOrderByNameAsc(language);
+        } else {
+            countries = countryRepository.findAllByOrderByNameAsc();
+        }
+        return countries.stream()
+                .map(countryMapper::toDTO)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/jm/services/EducationLevelService.java
+++ b/src/main/java/com/jm/services/EducationLevelService.java
@@ -1,0 +1,45 @@
+package com.jm.services;
+
+import com.jm.dto.EducationLevelDTO;
+import com.jm.entity.EducationLevel;
+import com.jm.repository.EducationLevelRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class EducationLevelService {
+
+    private final EducationLevelRepository repository;
+
+    public List<EducationLevelDTO> findAll(String language) {
+        Map<UUID, EducationLevel> accumulator = new LinkedHashMap<>();
+        if (StringUtils.hasText(language)) {
+            repository.findByLanguageIgnoreCaseOrLanguageIsNullOrderBySortOrderAscNameAsc(language)
+                    .forEach(level -> accumulator.put(level.getId(), level));
+        } else {
+            repository.findAllByOrderBySortOrderAscNameAsc()
+                    .forEach(level -> accumulator.put(level.getId(), level));
+        }
+        return accumulator.values().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private EducationLevelDTO toDto(EducationLevel entity) {
+        return EducationLevelDTO.builder()
+                .id(entity.getId())
+                .code(entity.getCode())
+                .name(entity.getName())
+                .description(entity.getDescription())
+                .sortOrder(entity.getSortOrder())
+                .build();
+    }
+}

--- a/src/main/java/com/jm/services/FoodCategoryService.java
+++ b/src/main/java/com/jm/services/FoodCategoryService.java
@@ -1,0 +1,44 @@
+package com.jm.services;
+
+import com.jm.dto.FoodCategoryDTO;
+import com.jm.entity.FoodCategory;
+import com.jm.repository.FoodCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FoodCategoryService {
+
+    private final FoodCategoryRepository repository;
+
+    public List<FoodCategoryDTO> findAll(String language) {
+        Map<UUID, FoodCategory> accumulator = new LinkedHashMap<>();
+        if (StringUtils.hasText(language)) {
+            repository.findByLanguageIgnoreCaseOrLanguageIsNullOrderByNameAsc(language)
+                    .forEach(category -> accumulator.put(category.getId(), category));
+        } else {
+            repository.findAllByOrderByNameAsc()
+                    .forEach(category -> accumulator.put(category.getId(), category));
+        }
+        return accumulator.values().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private FoodCategoryDTO toDto(FoodCategory entity) {
+        return FoodCategoryDTO.builder()
+                .id(entity.getId())
+                .name(entity.getName())
+                .description(entity.getDescription())
+                .color(entity.getColor())
+                .build();
+    }
+}

--- a/src/main/java/com/jm/services/FoodService.java
+++ b/src/main/java/com/jm/services/FoodService.java
@@ -1,0 +1,68 @@
+package com.jm.services;
+
+import com.jm.dto.FoodDTO;
+import com.jm.entity.Food;
+import com.jm.repository.FoodRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FoodService {
+
+    private final FoodRepository repository;
+
+    public List<FoodDTO> findAll(String language, UUID categoryId) {
+        Map<UUID, Food> accumulator = new LinkedHashMap<>();
+        if (StringUtils.hasText(language)) {
+            if (categoryId != null) {
+                repository.findByFoodCategoryIdAndLanguageIgnoreCaseOrderByNameAsc(categoryId, language)
+                        .forEach(food -> accumulator.put(food.getId(), food));
+                repository.findByFoodCategoryIdAndLanguageIsNullOrderByNameAsc(categoryId)
+                        .forEach(food -> accumulator.putIfAbsent(food.getId(), food));
+            } else {
+                repository.findByLanguageIgnoreCaseOrderByNameAsc(language)
+                        .forEach(food -> accumulator.put(food.getId(), food));
+                repository.findByLanguageIsNullOrderByNameAsc()
+                        .forEach(food -> accumulator.putIfAbsent(food.getId(), food));
+            }
+        } else {
+            if (categoryId != null) {
+                repository.findByFoodCategoryIdAndLanguageIsNullOrderByNameAsc(categoryId)
+                        .forEach(food -> accumulator.put(food.getId(), food));
+            } else {
+                repository.findAllByOrderByNameAsc()
+                        .forEach(food -> accumulator.put(food.getId(), food));
+            }
+        }
+        return accumulator.values().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private FoodDTO toDto(Food entity) {
+        return FoodDTO.builder()
+                .id(entity.getId())
+                .code(entity.getCode())
+                .name(entity.getName())
+                .description(entity.getDescription())
+                .categoryId(entity.getFoodCategory() != null ? entity.getFoodCategory().getId() : null)
+                .categoryName(entity.getFoodCategory() != null ? entity.getFoodCategory().getName() : null)
+                .averageCalories(entity.getAverageCalories())
+                .averageProtein(entity.getAverageProtein())
+                .averageCarbs(entity.getAverageCarbs())
+                .averageFat(entity.getAverageFat())
+                .commonPortion(entity.getCommonPortion())
+                .commonPortionUnitId(entity.getCommonPortionUnit() != null ? entity.getCommonPortionUnit().getId() : null)
+                .commonPortionUnitName(
+                        entity.getCommonPortionUnit() != null ? entity.getCommonPortionUnit().getName() : null)
+                .build();
+    }
+}

--- a/src/main/java/com/jm/services/MealService.java
+++ b/src/main/java/com/jm/services/MealService.java
@@ -1,0 +1,46 @@
+package com.jm.services;
+
+import com.jm.dto.MealDTO;
+import com.jm.entity.Meal;
+import com.jm.repository.MealRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MealService {
+
+    private final MealRepository repository;
+
+    public List<MealDTO> findAll(String language) {
+        Map<UUID, Meal> accumulator = new LinkedHashMap<>();
+        if (StringUtils.hasText(language)) {
+            repository.findByLanguageIgnoreCaseOrLanguageIsNullOrderBySortOrderAscNameAsc(language)
+                    .forEach(meal -> accumulator.put(meal.getId(), meal));
+        } else {
+            repository.findAllByOrderBySortOrderAscNameAsc()
+                    .forEach(meal -> accumulator.put(meal.getId(), meal));
+        }
+        return accumulator.values().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private MealDTO toDto(Meal entity) {
+        return MealDTO.builder()
+                .id(entity.getId())
+                .code(entity.getCode())
+                .name(entity.getName())
+                .description(entity.getDescription())
+                .typicalTime(entity.getTypicalTime())
+                .sortOrder(entity.getSortOrder())
+                .build();
+    }
+}

--- a/src/main/java/com/jm/services/MeasurementUnitService.java
+++ b/src/main/java/com/jm/services/MeasurementUnitService.java
@@ -1,0 +1,48 @@
+package com.jm.services;
+
+import com.jm.dto.MeasurementUnitDTO;
+import com.jm.entity.MeasurementUnits;
+import com.jm.repository.MeasurementUnitRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MeasurementUnitService {
+
+    private final MeasurementUnitRepository repository;
+
+    public List<MeasurementUnitDTO> findAll(String language) {
+        Map<UUID, MeasurementUnits> accumulator = new LinkedHashMap<>();
+        if (StringUtils.hasText(language)) {
+            repository.findByLanguageIgnoreCaseOrLanguageIsNullOrderByNameAsc(language)
+                    .forEach(unit -> accumulator.put(unit.getId(), unit));
+        } else {
+            repository.findAllByOrderByNameAsc()
+                    .forEach(unit -> accumulator.put(unit.getId(), unit));
+        }
+        return accumulator.values().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private MeasurementUnitDTO toDto(MeasurementUnits entity) {
+        return MeasurementUnitDTO.builder()
+                .id(entity.getId())
+                .code(entity.getCode())
+                .name(entity.getName())
+                .symbol(entity.getSymbol())
+                .unitType(entity.getUnitType())
+                .conversionFactor(entity.getConversionFactor())
+                .baseUnit(entity.getBaseUnit())
+                .description(entity.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/com/jm/services/PathologyService.java
+++ b/src/main/java/com/jm/services/PathologyService.java
@@ -1,0 +1,47 @@
+package com.jm.services;
+
+import com.jm.dto.PathologyDTO;
+import com.jm.entity.Pathology;
+import com.jm.repository.PathologyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PathologyService {
+
+    private final PathologyRepository repository;
+
+    public List<PathologyDTO> findAll(String language) {
+        Map<UUID, Pathology> accumulator = new LinkedHashMap<>();
+        if (StringUtils.hasText(language)) {
+            repository.findByLanguageIgnoreCaseOrLanguageIsNullOrderByNameAsc(language)
+                    .forEach(pathology -> accumulator.put(pathology.getId(), pathology));
+        } else {
+            repository.findAllByOrderByNameAsc()
+                    .forEach(pathology -> accumulator.put(pathology.getId(), pathology));
+        }
+        return accumulator.values().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private PathologyDTO toDto(Pathology entity) {
+        return PathologyDTO.builder()
+                .id(entity.getId())
+                .code(entity.getCode())
+                .name(entity.getName())
+                .description(entity.getDescription())
+                .category(entity.getCategory())
+                .chronic(Boolean.TRUE.equals(entity.getIsChronic()))
+                .requiresMonitoring(Boolean.TRUE.equals(entity.getRequiresMonitoring()))
+                .build();
+    }
+}

--- a/src/main/java/com/jm/services/ProfessionService.java
+++ b/src/main/java/com/jm/services/ProfessionService.java
@@ -1,0 +1,44 @@
+package com.jm.services;
+
+import com.jm.dto.ProfessionDTO;
+import com.jm.entity.Profession;
+import com.jm.repository.ProfessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ProfessionService {
+
+    private final ProfessionRepository repository;
+
+    public List<ProfessionDTO> findAll(String language) {
+        Map<UUID, Profession> accumulator = new LinkedHashMap<>();
+        if (StringUtils.hasText(language)) {
+            repository.findByLanguageIgnoreCaseOrLanguageIsNullOrderByNameAsc(language)
+                    .forEach(profession -> accumulator.put(profession.getId(), profession));
+        } else {
+            repository.findAllByOrderByNameAsc()
+                    .forEach(profession -> accumulator.put(profession.getId(), profession));
+        }
+        return accumulator.values().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private ProfessionDTO toDto(Profession entity) {
+        return ProfessionDTO.builder()
+                .id(entity.getId())
+                .code(entity.getCode())
+                .name(entity.getName())
+                .description(entity.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/com/jm/services/UserService.java
+++ b/src/main/java/com/jm/services/UserService.java
@@ -6,7 +6,10 @@ import com.jm.entity.Users;
 import com.jm.execption.JMException;
 import com.jm.execption.ProblemType;
 import com.jm.mappers.UserMapper;
+import com.jm.repository.CityRepository;
 import com.jm.repository.CountryRepository;
+import com.jm.repository.EducationLevelRepository;
+import com.jm.repository.ProfessionRepository;
 import com.jm.repository.UserRepository;
 import com.jm.speciation.UserSpeciation;
 import org.slf4j.Logger;
@@ -30,14 +33,21 @@ public class UserService {
     private final MessageSource messageSource;
     private final PasswordEncoder passwordEncoder;
     private final CountryRepository countriesRepository;
+    private final CityRepository cityRepository;
+    private final EducationLevelRepository educationLevelRepository;
+    private final ProfessionRepository professionRepository;
 
     public UserService(UserRepository repository, UserMapper mapper, MessageSource messageSource,
-            PasswordEncoder passwordEncoder, CountryRepository countriesRepository) {
+            PasswordEncoder passwordEncoder, CountryRepository countriesRepository, CityRepository cityRepository,
+            EducationLevelRepository educationLevelRepository, ProfessionRepository professionRepository) {
         this.repository = repository;
         this.mapper = mapper;
         this.messageSource = messageSource;
         this.passwordEncoder = passwordEncoder;
         this.countriesRepository = countriesRepository;
+        this.cityRepository = cityRepository;
+        this.educationLevelRepository = educationLevelRepository;
+        this.professionRepository = professionRepository;
     }
 
     public Page<UserDTO> findAll(Pageable pageable, UserDTO filter) throws JMException {
@@ -46,7 +56,14 @@ public class UserService {
 
     public UserDTO createUser(UserDTO dto) {
         Users entity = mapper.toEntity(dto);
-        entity.setCountry(countriesRepository.findById(dto.getCountryId()).orElse(null));
+        entity.setCountry(dto.getCountryId() != null ? countriesRepository.findById(dto.getCountryId()).orElse(null) : null);
+        entity.setCity(dto.getCityId() != null ? cityRepository.findById(dto.getCityId()).orElse(null) : null);
+        entity.setEducationLevel(dto.getEducationLevelId() != null
+                ? educationLevelRepository.findById(dto.getEducationLevelId()).orElse(null)
+                : null);
+        entity.setProfession(dto.getProfessionId() != null
+                ? professionRepository.findById(dto.getProfessionId()).orElse(null)
+                : null);
         if (!StringUtils.hasText(entity.getPassword()) && dto.getId() != null) {
             repository.findById(dto.getId()).ifPresent(existing -> entity.setPassword(existing.getPassword()));
         }

--- a/src/main/java/com/jm/speciation/UserSpeciation.java
+++ b/src/main/java/com/jm/speciation/UserSpeciation.java
@@ -2,8 +2,10 @@ package com.jm.speciation;
 
 import com.jm.dto.UserDTO;
 import com.jm.entity.Users;
+import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,13 +16,31 @@ public class UserSpeciation {
     public static Specification<Users> search(UserDTO filter) {
         return (root, query, builder) -> {
             List<Predicate> predicates = new ArrayList<>();
-            if (Objects.nonNull(filter.getName()) && !filter.getName().isEmpty()) {
-                predicates.add(builder.like(builder.lower(root.<String>get("name")),
+            if (StringUtils.hasText(filter.getName())) {
+                predicates.add(builder.like(builder.lower(root.get("name")),
                         "%".concat(filter.getName().toLowerCase()).concat("%")));
             }
-            if (Objects.nonNull(filter.getPhoneNumber()) && !filter.getPhoneNumber().isEmpty()) {
-                predicates.add(builder.equal(builder.lower(root.<String>get("phoneNumber")),
-                        filter.getPhoneNumber().toLowerCase()));
+            if (StringUtils.hasText(filter.getEmail())) {
+                predicates.add(builder.like(builder.lower(root.get("email")),
+                        "%".concat(filter.getEmail().toLowerCase()).concat("%")));
+            }
+            if (StringUtils.hasText(filter.getPhoneNumber())) {
+                predicates.add(builder.like(builder.lower(root.get("phoneNumber")),
+                        "%".concat(filter.getPhoneNumber().toLowerCase()).concat("%")));
+            }
+            if (Objects.nonNull(filter.getCountryId())) {
+                predicates.add(builder.equal(root.join("country", JoinType.LEFT).get("id"), filter.getCountryId()));
+            }
+            if (Objects.nonNull(filter.getCityId())) {
+                predicates.add(builder.equal(root.join("city", JoinType.LEFT).get("id"), filter.getCityId()));
+            }
+            if (Objects.nonNull(filter.getEducationLevelId())) {
+                predicates.add(builder.equal(root.join("educationLevel", JoinType.LEFT).get("id"),
+                        filter.getEducationLevelId()));
+            }
+            if (Objects.nonNull(filter.getProfessionId())) {
+                predicates.add(builder.equal(root.join("profession", JoinType.LEFT).get("id"),
+                        filter.getProfessionId()));
             }
 
             return builder.and(predicates.toArray(new Predicate[0]));

--- a/src/main/resources/db/migration/V15__202510121100_create_and_seed_cities.sql
+++ b/src/main/resources/db/migration/V15__202510121100_create_and_seed_cities.sql
@@ -1,0 +1,72 @@
+ALTER TABLE food_categories
+    ADD COLUMN IF NOT EXISTS language VARCHAR(5) DEFAULT NULL AFTER color;
+
+UPDATE food_categories SET language = 'en' WHERE language IS NULL;
+
+CREATE TABLE IF NOT EXISTS cities (
+    id CHAR(36) PRIMARY KEY,
+    country_id CHAR(36) NOT NULL,
+    state_code VARCHAR(10) NOT NULL,
+    state_name VARCHAR(100) NOT NULL,
+    city_code VARCHAR(20),
+    name VARCHAR(100) NOT NULL,
+    latitude DECIMAL(10, 8),
+    longitude DECIMAL(11, 8),
+    population INT,
+    timezone VARCHAR(50),
+    is_capital BOOLEAN DEFAULT FALSE,
+    is_active BOOLEAN DEFAULT TRUE,
+    language VARCHAR(5) DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_cities_country FOREIGN KEY (country_id) REFERENCES countries(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cities_country ON cities(country_id);
+CREATE INDEX IF NOT EXISTS idx_cities_name ON cities(name);
+
+ALTER TABLE user_entity
+    ADD COLUMN IF NOT EXISTS city_id CHAR(36) NULL AFTER street;
+
+ALTER TABLE user_entity
+    ADD COLUMN IF NOT EXISTS education_level_id CHAR(36) NULL AFTER age;
+
+ALTER TABLE user_entity
+    ADD COLUMN IF NOT EXISTS profession_id CHAR(36) NULL AFTER education_level_id;
+
+ALTER TABLE user_entity
+    ADD CONSTRAINT fk_user_entity_city FOREIGN KEY (city_id) REFERENCES cities(id);
+
+ALTER TABLE user_entity
+    ADD CONSTRAINT fk_user_entity_education FOREIGN KEY (education_level_id) REFERENCES education_levels(id);
+
+ALTER TABLE user_entity
+    ADD CONSTRAINT fk_user_entity_profession FOREIGN KEY (profession_id) REFERENCES professions(id);
+
+CREATE INDEX IF NOT EXISTS idx_user_entity_city_id ON user_entity (city_id);
+CREATE INDEX IF NOT EXISTS idx_user_entity_education_id ON user_entity (education_level_id);
+CREATE INDEX IF NOT EXISTS idx_user_entity_profession_id ON user_entity (profession_id);
+
+INSERT INTO cities (id, country_id, state_code, state_name, city_code, name, latitude, longitude, population, timezone,
+                    is_capital, language)
+VALUES
+    (UUID(), (SELECT id FROM countries WHERE code = 'US' LIMIT 1), 'CA', 'California', 'US-LAX', 'Los Angeles',
+     34.052235, -118.243683, 3898747, 'America/Los_Angeles', FALSE, 'en'),
+    (UUID(), (SELECT id FROM countries WHERE code = 'US' LIMIT 1), 'NY', 'New York', 'US-NYC', 'New York',
+     40.712776, -74.005974, 8804190, 'America/New_York', FALSE, 'en'),
+    (UUID(), (SELECT id FROM countries WHERE code = 'US' LIMIT 1), 'DC', 'District of Columbia', 'US-WAS', 'Washington',
+     38.907192, -77.036873, 689545, 'America/New_York', TRUE, 'en'),
+    (UUID(), (SELECT id FROM countries WHERE code = 'BR' LIMIT 1), 'SP', 'São Paulo', 'BR-SAO', 'São Paulo',
+     -23.550520, -46.633308, 12330000, 'America/Sao_Paulo', FALSE, 'pt'),
+    (UUID(), (SELECT id FROM countries WHERE code = 'BR' LIMIT 1), 'RJ', 'Rio de Janeiro', 'BR-RIO', 'Rio de Janeiro',
+     -22.906847, -43.172897, 6718903, 'America/Sao_Paulo', FALSE, 'pt'),
+    (UUID(), (SELECT id FROM countries WHERE code = 'BR' LIMIT 1), 'DF', 'Distrito Federal', 'BR-BSB', 'Brasília',
+     -15.780148, -47.929169, 3055149, 'America/Sao_Paulo', TRUE, 'pt'),
+    (UUID(), (SELECT id FROM countries WHERE code = 'PT' LIMIT 1), 'LX', 'Lisboa', 'PT-LIS', 'Lisboa',
+     38.722252, -9.139337, 544851, 'Europe/Lisbon', TRUE, 'pt'),
+    (UUID(), (SELECT id FROM countries WHERE code = 'PT' LIMIT 1), 'PRT', 'Porto', 'PT-PRT', 'Porto',
+     41.157944, -8.629105, 237559, 'Europe/Lisbon', FALSE, 'pt'),
+    (UUID(), (SELECT id FROM countries WHERE code = 'CA' LIMIT 1), 'ON', 'Ontario', 'CA-TOR', 'Toronto',
+     43.653225, -79.383186, 2731571, 'America/Toronto', FALSE, 'en'),
+    (UUID(), (SELECT id FROM countries WHERE code = 'CA' LIMIT 1), 'BC', 'British Columbia', 'CA-VAN', 'Vancouver',
+     49.282729, -123.120738, 662248, 'America/Vancouver', FALSE, 'en');


### PR DESCRIPTION
## Summary
- add reference data controller, services, and repositories to expose localized lookups for countries, cities, education, professions, and nutrition tables
- link users and anamneses to the new foreign key entities and seed key city data through Flyway
- update profile and user list views plus shared styles to consume localized reference APIs and respect dark mode

## Testing
- `./mvnw -DskipTests compile`


------
https://chatgpt.com/codex/tasks/task_e_68e657a5bb9c832aa06303d45e5f81c3